### PR TITLE
Allow strings to be compared.

### DIFF
--- a/src/runtime/lib/string.js
+++ b/src/runtime/lib/string.js
@@ -43,6 +43,9 @@ function translatePattern (pattern) {
 	// TODO Add support for balanced character matching (not sure this is easily achieveable).
 	pattern = '' + pattern;
 
+	// Replace single backslash with double backslashes
+	pattern = pattern.replace(new RegExp('\\\\', 'g'), '\\\\');
+
 	for (let i in ROSETTA_STONE) {
 		if (ROSETTA_STONE.hasOwnProperty(i)) {
 			pattern = pattern.replace(new RegExp(i, 'g'), ROSETTA_STONE[i]);

--- a/src/runtime/operators.js
+++ b/src/runtime/operators.js
@@ -24,6 +24,14 @@ function binaryArithmetic(left, right, metaMethodName, callback) {
 }
 
 
+function binaryStringArithmetic(left, right, metaMethodName, callback) {
+	if (typeof left == 'string' && typeof right == 'string') {
+		return callback(left, right);
+	}
+	return binaryArithmetic(left, right, metaMethodName, callback);
+}
+
+
 function concat(left, right) {
 	let mt, f;
 
@@ -134,8 +142,8 @@ const op = {
 	},
 	mod: (left, right) => binaryArithmetic(left, right, '__mod', mod),
 	pow: (left, right) => binaryArithmetic(left, right, '__pow', Math.pow),
-	lt: (left, right) => binaryArithmetic(left, right, '__lt', (l, r) => l < r),
-	lte: (left, right) => binaryArithmetic(left, right, '__le', (l, r) => l <= r),
+	lt: (left, right) => binaryStringArithmetic(left, right, '__lt', (l, r) => l < r),
+	lte: (left, right) => binaryStringArithmetic(left, right, '__le', (l, r) => l <= r),
 	
 	gt(left, right) {
 		return !op.lte(left, right);


### PR DESCRIPTION
This change lets strings be compared using comparison operators without generating an error.

Example test case fixed:
```lua
    assertTrue("abc" < "def", "Strings should be comparable")
```